### PR TITLE
Fix asset bundling to support Parcel v1.10+

### DIFF
--- a/RiotAsset.js
+++ b/RiotAsset.js
@@ -1,17 +1,26 @@
 const { compile } = require('riot-compiler');
-const JSAsset = require('parcel-bundler/src/assets/JSAsset');
+const { Asset } = require('parcel-bundler');
 const preamble = "const riot = require('riot');\n";
 
-class RiotAsset extends JSAsset {
+class RiotAsset extends Asset {
+  constructor(name, options) {
+    super(name, options);
+    this.type = 'js';
+  }
 
-  async parse(inputCode) {
+  async generate() {
     const riotOpts = {};
 
-    let code = compile(inputCode, riotOpts, this.name);
+    let code = compile(this.contents, riotOpts, this.name);
     code = `${ preamble }${ code }`;
     this.contents = code;
 
-    return super.parse(this.contents);
+    return [
+      {
+        type: 'js',
+        value: this.contents
+      }
+    ];
   }
 }
 


### PR DESCRIPTION
Currently `parcel-plugin-riot` is giving errors when using Parcel v1.10.0 and above. This fixes those errors by using updated structure in the asset bundling.